### PR TITLE
RepositoryListCellに説明文を追加（Task2）

### DIFF
--- a/AbemaTutorial/Sources/Views/RepositoryList/Cell/RepositoryListCell.swift
+++ b/AbemaTutorial/Sources/Views/RepositoryList/Cell/RepositoryListCell.swift
@@ -20,6 +20,10 @@ final class RepositoryListCell: UITableViewCell {
         viewStream.output.titleText
             .bind(to: textLabel!.rx.text)
             .disposed(by: disposeBag)
+        
+        viewStream.output.descriptionText
+            .bind(to: detailTextLabel!.rx.text)
+            .disposed(by: disposeBag)
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/AbemaTutorial/Sources/Views/RepositoryList/Cell/RepositoryListCellStream.swift
+++ b/AbemaTutorial/Sources/Views/RepositoryList/Cell/RepositoryListCellStream.swift
@@ -25,10 +25,12 @@ extension RepositoryListCellStream {
 
     struct Output: OutputType {
         let titleText: BehaviorRelay<String>
+        let descriptionText: BehaviorRelay<String>
     }
 
     struct State: StateType {
         let titleText = BehaviorRelay<String>(value: "")
+        let descriptionText = BehaviorRelay<String>(value: "")
     }
 
     struct Extra: ExtraType {}
@@ -48,7 +50,11 @@ extension RepositoryListCellStream {
             .map { "\($0.owner.login) / \($0.name)" }
             .bind(to: state.titleText)
             .disposed(by: disposeBag)
+        
+        repository.map { $0.description }
+            .bind(to: state.descriptionText)
+            .disposed(by: disposeBag)
 
-        return Output(titleText: state.titleText)
+        return Output(titleText: state.titleText, descriptionText: state.descriptionText)
     }
 }

--- a/AbemaTutorialTests/Tests/Views/RepositoryList/RepositoryListCellStreamTests.swift
+++ b/AbemaTutorialTests/Tests/Views/RepositoryList/RepositoryListCellStreamTests.swift
@@ -24,6 +24,26 @@ final class RepositoryListCellStreamTests: XCTestCase {
 
         XCTAssertEqual(titleText.value, "owner / name")
     }
+    
+    func testDescriptionText() {
+        // Testするクラスを取得
+        let testTarget = dependency.testTarget
+        
+        // Inputに流すデータを作成
+        let repository = Repository.init(id: 1, name: "test_name", description: "test_description", owner: User(id: 123, login: "owner"))
+        
+        // outputをWatchStackに入れてテスタブルにする
+        let descriptionText = WatchStack(testTarget.output.descriptionText)
+        
+        // 流す前のデータを確認（いらないかも）
+        XCTAssertEqual(descriptionText.value, "")
+        
+        // Inputを流して、データの状態を変更する
+        testTarget.input.accept(repository, for: \.repository)
+        
+        // 結果をチェックする
+        XCTAssertEqual(descriptionText.value, "test_description")
+    }
 }
 
 extension RepositoryListCellStreamTests {


### PR DESCRIPTION
- close #5 

# 説明
`RepositoryListCell.detailTextLabel`に説明文のデータを流して表示する。

## UnitTestの目的
レポジトリから流れたデータがしっかり`output`として伝わっているかの確認のため、前後でXCAssertを入れてみた。