### PR TITLE
APIエラー時にアラートの表示・閉じるボタンをタップして再フェッチ（Task3）

### DIFF
--- a/AbemaTutorial/Resources/Localizable.strings
+++ b/AbemaTutorial/Resources/Localizable.strings
@@ -1,2 +1,4 @@
 // MARK: - Button
 "Close" = "閉じる";
+"Error" = "エラー";
+"Sorry, something unexpected happened. Please try again later." = "エラーが発生しました。もう一度お試しください。";

--- a/AbemaTutorial/Sources/API/APIClient.swift
+++ b/AbemaTutorial/Sources/API/APIClient.swift
@@ -28,7 +28,7 @@ extension APIClient {
             .delay(.seconds(1), scheduler: SerialDispatchQueueScheduler(qos: .default))
             .map { _ in Array(repositories[offset ..< offset + limit]) }
             .flatMap { repositories -> Observable<[Repository]> in
-                Int.random(in: 0 ..< 10) > 0 ? .just(repositories) : .error(APIError.internalServerError)
+                Int.random(in: 0 ..< 10) > 5 ? .just(repositories) : .error(APIError.internalServerError)
             }
     }
 }

--- a/AbemaTutorial/Sources/Gens/StringsGen.swift
+++ b/AbemaTutorial/Sources/Gens/StringsGen.swift
@@ -12,6 +12,10 @@ import Foundation
 internal enum L10n {
   /// 閉じる
   internal static let close = L10n.tr("Localizable", "Close")
+  /// エラー
+  internal static let error = L10n.tr("Localizable", "Error")
+  /// エラーが発生しました。もう一度お試しください。
+  internal static let sorrySomethingUnexpectedHappenedPleaseTryAgainLater = L10n.tr("Localizable", "Sorry, something unexpected happened. Please try again later.")
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 

--- a/AbemaTutorial/Sources/Views/RepositoryList/RepositoryListViewController.swift
+++ b/AbemaTutorial/Sources/Views/RepositoryList/RepositoryListViewController.swift
@@ -34,6 +34,17 @@ final class RepositoryListViewController: UIViewController {
             })
             .disposed(by: disposeBag)
 
+        viewStream.output.failedToFetchRespositories
+            .observeOn(MainScheduler.instance)
+            .subscribe(onNext: { [weak self] in
+                let alert = UIAlertController(title: L10n.error, message: L10n.sorrySomethingUnexpectedHappenedPleaseTryAgainLater, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: L10n.close, style: .default, handler: { [weak self] _ in
+                    self?.viewStream.input.accept((), for: \.retryFetchingRepositories)
+                }))
+                self?.present(alert, animated: true, completion: nil)
+            })
+            .disposed(by: disposeBag)
+        
         viewStream.output.isRefreshControlRefreshing
             .bind(to: refreshControl.rx.isRefreshing)
             .disposed(by: disposeBag)

--- a/AbemaTutorialTests/Tests/Flux/Repository/RepositoryActionTests.swift
+++ b/AbemaTutorialTests/Tests/Flux/Repository/RepositoryActionTests.swift
@@ -30,7 +30,7 @@ final class RepositoryActionTests: XCTestCase {
         // APIClientから結果返却後
         apiClient._fetchRepositories.accept(.next([mockRepository]))
         apiClient._fetchRepositories.accept(.completed)
-
+ 
         XCTAssertEqual(fetchRepositories.events, [.next(true), .completed])
     }
     

--- a/AbemaTutorialTests/Tests/Flux/Repository/RepositoryActionTests.swift
+++ b/AbemaTutorialTests/Tests/Flux/Repository/RepositoryActionTests.swift
@@ -33,6 +33,24 @@ final class RepositoryActionTests: XCTestCase {
 
         XCTAssertEqual(fetchRepositories.events, [.next(true), .completed])
     }
+    
+    func testFailFetchingRepositories() {
+        // setup
+        let testTarget = dependency.testTarget
+        let apiClient = dependency.apiClient
+        
+        // input
+        let fetchRepositories = WatchStack(testTarget.fetchRepositories(limit: 123, offset: 123).map { true })
+        
+        // check initial state.
+        XCTAssertEqual(fetchRepositories.events, [])
+        
+        // call api.
+        apiClient._fetchRepositories.accept(.error(APIError.internalServerError))
+        
+        // check after error happened.
+        XCTAssertEqual(fetchRepositories.events, [.error(APIError.internalServerError)])
+    }
 }
 
 extension RepositoryActionTests {

--- a/AbemaTutorialTests/Tests/Views/RepositoryList/RepositoryListViewStreamTests.swift
+++ b/AbemaTutorialTests/Tests/Views/RepositoryList/RepositoryListViewStreamTests.swift
@@ -22,12 +22,15 @@ final class RepositoryListViewStreamTests: XCTestCase {
         let repositories = WatchStack(testTarget.output.repositories)
         let reloadData = WatchStack(testTarget.output.reloadData.map { true }) // Voidだと比較できないのでBool化
         let isRefreshControlRefreshing = WatchStack(testTarget.output.isRefreshControlRefreshing)
+        let failedToFetchRespositories = WatchStack(testTarget.output.failedToFetchRespositories.map { true }) // voidで比較できない
 
         // 初期状態
 
         XCTAssertEqual(repositories.value, [])
         XCTAssertEqual(reloadData.events, [])
         XCTAssertEqual(isRefreshControlRefreshing.value, false)
+        // PubishRelayに関しては、TestableObserver.eventsでcheckしてあげる
+        XCTAssertEqual(failedToFetchRespositories.events, [])
 
         // viewWillAppearの後
 
@@ -36,6 +39,7 @@ final class RepositoryListViewStreamTests: XCTestCase {
         XCTAssertEqual(repositories.value, [])
         XCTAssertEqual(reloadData.events, [])
         XCTAssertEqual(isRefreshControlRefreshing.value, true)
+        XCTAssertEqual(failedToFetchRespositories.events, [])
 
         // データが返ってきた後
 
@@ -46,6 +50,7 @@ final class RepositoryListViewStreamTests: XCTestCase {
         XCTAssertEqual(repositories.value, [mockRepository])
         XCTAssertEqual(reloadData.events, [.next(true)])
         XCTAssertEqual(isRefreshControlRefreshing.value, false)
+        XCTAssertEqual(failedToFetchRespositories.events, [])
 
         // リフレッシュ後
 
@@ -54,16 +59,57 @@ final class RepositoryListViewStreamTests: XCTestCase {
         XCTAssertEqual(repositories.value, [mockRepository])
         XCTAssertEqual(reloadData.events, [.next(true)])
         XCTAssertEqual(isRefreshControlRefreshing.value, true)
+        XCTAssertEqual(failedToFetchRespositories.events, [])
 
         // データが返ってきた後
 
         repositoryAction._fetchResult.accept(.next(()))
         repositoryAction._fetchResult.accept(.completed)
         repositoryStore._repositories.accept([mockRepository])
+        XCTAssertEqual(failedToFetchRespositories.events, [])
 
         XCTAssertEqual(repositories.value, [mockRepository])
         XCTAssertEqual(reloadData.events, [.next(true), .next(true)])
         XCTAssertEqual(isRefreshControlRefreshing.value, false)
+    }
+    
+    func testRefreshControlValueChanged() {
+        // setup
+        let testTarget = dependency.testTarget
+        let repositoryAction = dependency.repositoryAction
+        let repositoryStore = dependency.repositoryStore
+        
+        let mockRepository = Repository.mock()
+        
+        let repositories = WatchStack(testTarget.output.repositories)
+        let reloadData = WatchStack(testTarget.output.reloadData.map { true })
+        let isRefreshControlRefreshing = WatchStack(testTarget.output.isRefreshControlRefreshing)
+        let failedToFetchRespositories = WatchStack(testTarget.output.failedToFetchRespositories.map { true })
+        
+        // check initial state.
+        XCTAssertEqual(repositories.value, [])
+        XCTAssertEqual(reloadData.events, [])
+        XCTAssertEqual(isRefreshControlRefreshing.value, false)
+        XCTAssertEqual(failedToFetchRespositories.events, [])
+        
+        // input
+        testTarget.input.accept((), for: \.refreshControlValueChanged)
+        
+        // check after refreshControlValueChanged
+        XCTAssertEqual(repositories.value, [])
+        XCTAssertEqual(reloadData.events, [])
+        XCTAssertEqual(isRefreshControlRefreshing.value, true)
+        XCTAssertEqual(failedToFetchRespositories.events, [])
+        
+        // get repositories
+        repositoryAction._fetchResult.accept(.next(()))
+        repositoryAction._fetchResult.accept(.completed)
+        repositoryStore._repositories.accept([mockRepository])
+        
+        XCTAssertEqual(repositories.value, [mockRepository])
+        XCTAssertEqual(reloadData.events, [])
+        XCTAssertEqual(isRefreshControlRefreshing.value, false)
+        XCTAssertEqual(failedToFetchRespositories.events, [])
     }
 }
 


### PR DESCRIPTION
close #7 

# 説明
APIClientがエラーを吐いた時にアラートを表示して、アラートの閉じるボタンをタップしたらもう一度データを取得する機能の追加。

---

## サンプルとの違いと気づき（IMO）

- 誰が主語かで命名規則が変わってきそう
    - 「APIフェッチに失敗した」という挙動から名付けた `failedToFetchRespositories` はAPIClientに依存しているViewStreamからしたら普通の命名だと思う。APIフェッチ時のUIの仕様が変わっても柔軟に対応できそう。（`showFailureAlert`みたいなUIに依存している命名より個人的にこっちの方が好み）
    - だけど、`retryFetchingRepositories`はInputとOutputの因果関係が成り立っていない。closeボタンを押したからといって必ず retryFetchingRepositoriesが示す挙動を行うのは今は正しいけど、UIがViewModelやAPIの挙動を知っている感じになっているのがどっちが良いのか疑問になった。（`failedAlertTapped`とかの方が好み）

```swift
extension RepositoryListViewStream {
    struct Input: InputType {
        let retryFetchingRepositories = PublishRelay<Void>()
    }

    struct Output: OutputType {
        let failedToFetchRespositories: PublishRelay<Void>
    }
}
```

- Testの量が全然違う
**初期に書いてたテストコード**
```swift
func testFailFetchingRepositories() {
    // setup
    let testTarget = dependency.testTarget
    let apiClient = dependency.apiClient
    
    // input
    let fetchRepositories = WatchStack(testTarget.fetchRepositories(limit: 123, offset: 123).map { true })
    
    // check initial state.
    XCTAssertEqual(fetchRepositories.events, [])
    
    // call api.
    apiClient._fetchRepositories.accept(.error(APIError.internalServerError))
    
    // check after error happened.
    XCTAssertEqual(fetchRepositories.events, [.error(APIError.internalServerError)])
```

- testして分かること
    - Errorを流したらちゃんと**Action**のOutputに伝わっている

- testしたいこと
    -  ~Errorを流したら**ViewStream**のOutputまで流れてくる~
    - ViewStreamの`Input.retryFetchingRepositories`からデータが流れるとOutputが流れている

> Errorを流したら**ViewStream**のOutputまで流れてくる

フォルダの階層的に Flux > Repository > ActionTestだからActionで止まって良いのか

**変数・メソッドを追加したらテストを追加する習慣が大切**な気がする